### PR TITLE
Fix two bugs of local BIC score: incorrect covariance and data centering

### DIFF
--- a/causallearn/score/LocalScoreFunction.py
+++ b/causallearn/score/LocalScoreFunction.py
@@ -22,7 +22,7 @@ def local_score_BIC(Data: ndarray, i: int, PAi: List[int], parameters=None) -> f
     score: local BIC score
     """
 
-    cov = np.corrcoef(Data.T)
+    cov = np.cov(Data.T)
     n = Data.shape[0]
     # cov, n = Data
 

--- a/causallearn/score/LocalScoreFunctionClass.py
+++ b/causallearn/score/LocalScoreFunctionClass.py
@@ -30,7 +30,7 @@ class LocalScoreClass(object):
         self.score_cache = {}
 
         if self.local_score_fun == local_score_BIC_from_cov:
-            self.cov = np.corrcoef(self.data.T)
+            self.cov = np.cov(self.data.T)
             self.n = self.data.shape[0]
 
     def score(self, i: int, PAi: List[int]) -> float:


### PR DESCRIPTION
### Updated files:

+ `score/LocalScoreFunction.py`: In `def local_score_BIC`, replace `cov = np.corrcoef(Data.T)` by `cov = np.cov(Data.T)`.
+ `score/LocalScoreFunctionClass.py`: In `class LocalScoreClass`, replace `self.cov = np.corrcoef(self.data.T)` by `self.cov = np.cov(self.data.T)`.

### Two bugs solved:
+ In the earliest local BIC score (as of 5a3219efa60f6d60387363358f6a97401d7546ce), covariance is calculated as `cov(Xi,Xj)=E(XiXj)`, i.e., the data is assumed to be centered. However, the calls to score functions do not explicitly center data. Thus e.g., under a constant shift, `GES(data)` and `GES(data+1)` will output very different results. See examples [here](https://gist.github.com/MarkDana/8086c5c1799e133459312e81c3f360f8).
+ In a later update (after a0db10a5e5d35b04ee2a0fcbf34c3110797a1c76), the covariance matrix numpy API was misused as `np.corrcoef`.  (I'm not sure whether this is a bug or equivalent to cov. See examples [here](https://gist.github.com/MarkDana/8086c5c1799e133459312e81c3f360f8). For this pr, just to make codes consistent as before.)


### Traceback:

+ The earliest local BIC score (as of 5a3219efa60f6d60387363358f6a97401d7546ce) is calculated by inner product among data samples. See [here](https://github.com/MarkDana/causal-learn/blob/5a3219efa60f6d60387363358f6a97401d7546ce/causallearn/score/LocalScoreFunction.py#L36).
+ With centered data, then the previous one is equivalent to using the covariance matrix (just extract the [`/ T`](https://github.com/MarkDana/causal-learn/blob/5a3219efa60f6d60387363358f6a97401d7546ce/causallearn/score/LocalScoreFunction.py#L41) term out).
+ Hence an update (`local_score_BIC_from_cov`) was made at a0db10a5e5d35b04ee2a0fcbf34c3110797a1c76. See [here](https://github.com/MarkDana/causal-learn/blob/a0db10a5e5d35b04ee2a0fcbf34c3110797a1c76/causallearn/score/LocalScoreFunction.py#L51). Codes are more readable.
+ And further it is merged into `local_score_BIC` at 87bcc721e079f52ddc656d4fa8e3da3e15b379d7. See [here](https://github.com/py-why/causal-learn/blob/87bcc721e079f52ddc656d4fa8e3da3e15b379d7/causallearn/score/LocalScoreFunction.py#L9).
+ Then the precomputed covariance matrix is added back to save time. See [here](https://github.com/py-why/causal-learn/blob/80128fcdb089a229f210adb7f939660e2091241e/causallearn/score/LocalScoreFunctionClass.py#L20).

### Test plan:
```bash
python -m unittest TestGES    # should pass
python -m unittest TestGRaSP    # should pass
python -m unittest TestLocalScore   # should pass
```

**TODO:** The above three tests passed without any modification to the benchmark results (if any). Considering the above fixed bugs (especially 1), if the previous benchmark tests also passed with the bugs, then these benchmarks are not comprehensive to ensure the codes correctness. Some more cases design is needed.