### PR TITLE
Remove unnecessary print

### DIFF
--- a/causallearn/graph/Dag.py
+++ b/causallearn/graph/Dag.py
@@ -255,9 +255,6 @@ class Dag(GeneralGraph):
         i = self.node_map[node]
         children = []
 
-        print(self.nodes)
-        print(self.num_vars)
-
         for j in range(len(self.nodes)):
             if self.graph[j, i] == 1:
                 node2 = self.nodes[j]


### PR DESCRIPTION
In the current version of `graph/Dag.py`, there are two `print` statements in the `get_children` function that seem to be unnecessary and will pollute the program output when `get_children` is frequently used. Since the change does not affect the overall functionality, I did not run the unit tests.