### PR TITLE
Fix a numerical issue in fisherz

### DIFF
--- a/causallearn/utils/cit.py
+++ b/causallearn/utils/cit.py
@@ -163,6 +163,7 @@ class FisherZ(CIT_Base):
         except np.linalg.LinAlgError:
             raise ValueError('Data correlation matrix is singular. Cannot run fisherz test. Please check your data.')
         r = -inv[0, 1] / sqrt(inv[0, 0] * inv[1, 1])
+        if abs(r) >= 1: r = (1. - np.finfo(float).eps) * np.sign(r) # may happen when samplesize is very small
         Z = 0.5 * log((1 + r) / (1 - r))
         X = sqrt(self.sample_size - len(condition_set) - 3) * abs(Z)
         p = 2 * (1 - norm.cdf(abs(X)))
@@ -382,6 +383,7 @@ class MV_FisherZ(CIT_Base):
         except np.linalg.LinAlgError:
             raise ValueError('Data correlation matrix is singular. Cannot run fisherz test. Please check your data.')
         r = -inv[0, 1] / sqrt(inv[0, 0] * inv[1, 1])
+        if abs(r) >= 1: r = (1. - np.finfo(float).eps) * np.sign(r) # may happen when samplesize is very small
         Z = 0.5 * log((1 + r) / (1 - r))
         X = sqrt(len(test_wise_deletion_XYcond_rows_index) - len(condition_set) - 3) * abs(Z)
         p = 2 * (1 - norm.cdf(abs(X)))

--- a/causallearn/utils/cit.py
+++ b/causallearn/utils/cit.py
@@ -163,7 +163,7 @@ class FisherZ(CIT_Base):
         except np.linalg.LinAlgError:
             raise ValueError('Data correlation matrix is singular. Cannot run fisherz test. Please check your data.')
         r = -inv[0, 1] / sqrt(inv[0, 0] * inv[1, 1])
-        if abs(r) >= 1: r = (1. - np.finfo(float).eps) * np.sign(r) # may happen when samplesize is very small
+        if abs(r) >= 1: r = (1. - np.finfo(float).eps) * np.sign(r) # may happen when samplesize is very small or relation is deterministic
         Z = 0.5 * log((1 + r) / (1 - r))
         X = sqrt(self.sample_size - len(condition_set) - 3) * abs(Z)
         p = 2 * (1 - norm.cdf(abs(X)))
@@ -383,7 +383,7 @@ class MV_FisherZ(CIT_Base):
         except np.linalg.LinAlgError:
             raise ValueError('Data correlation matrix is singular. Cannot run fisherz test. Please check your data.')
         r = -inv[0, 1] / sqrt(inv[0, 0] * inv[1, 1])
-        if abs(r) >= 1: r = (1. - np.finfo(float).eps) * np.sign(r) # may happen when samplesize is very small
+        if abs(r) >= 1: r = (1. - np.finfo(float).eps) * np.sign(r) # may happen when samplesize is very small or relation is deterministic
         Z = 0.5 * log((1 + r) / (1 - r))
         X = sqrt(len(test_wise_deletion_XYcond_rows_index) - len(condition_set) - 3) * abs(Z)
         p = 2 * (1 - norm.cdf(abs(X)))


### PR DESCRIPTION
See issue https://github.com/py-why/causal-learn/issues/107 for details.

The numerical issue of |sample partial correlation|>=1 happens when the samplesize is very small, or the relationship is deterministic.

Abs set to 1. - machine epsilon.

No tests required.