### PR TITLE
Fixed the endpoint comparison bug

### DIFF
--- a/causallearn/graph/Edge.py
+++ b/causallearn/graph/Edge.py
@@ -82,28 +82,28 @@ class Edge:
         self.endpoint1 = endpoint
 
         if self.numerical_endpoint_1 == 1 and self.numerical_endpoint_2 == 1:
-            if endpoint is Endpoint.ARROW:
+            if endpoint == Endpoint.ARROW:
                 pass
             else:
-                if endpoint is Endpoint.TAIL:
+                if endpoint == Endpoint.TAIL:
                     self.numerical_endpoint_1 = -1
                     self.numerical_endpoint_2 = 1
                 else:
-                    if endpoint is Endpoint.CIRCLE:
+                    if endpoint == Endpoint.CIRCLE:
                         self.numerical_endpoint_1 = 2
                         self.numerical_endpoint_2 = 1
         else:
-            if endpoint is Endpoint.ARROW and self.numerical_endpoint_2 == 1:
+            if endpoint == Endpoint.ARROW and self.numerical_endpoint_2 == 1:
                 self.numerical_endpoint_1 = 1
                 self.numerical_endpoint_2 = 1
             else:
-                if endpoint is Endpoint.ARROW:
+                if endpoint == Endpoint.ARROW:
                     self.numerical_endpoint_1 = 1
                 else:
-                    if endpoint is Endpoint.TAIL:
+                    if endpoint == Endpoint.TAIL:
                         self.numerical_endpoint_1 = -1
                     else:
-                        if endpoint is Endpoint.CIRCLE:
+                        if endpoint == Endpoint.CIRCLE:
                             self.numerical_endpoint_1 = 2
 
         if self.pointing_left(self.endpoint1, self.endpoint2):
@@ -123,28 +123,28 @@ class Edge:
         self.endpoint2 = endpoint
 
         if self.numerical_endpoint_1 == 1 and self.numerical_endpoint_2 == 1:
-            if endpoint is Endpoint.ARROW:
+            if endpoint == Endpoint.ARROW:
                 pass
             else:
-                if endpoint is Endpoint.TAIL:
+                if endpoint == Endpoint.TAIL:
                     self.numerical_endpoint_1 = 1
                     self.numerical_endpoint_2 = -1
                 else:
-                    if endpoint is Endpoint.CIRCLE:
+                    if endpoint == Endpoint.CIRCLE:
                         self.numerical_endpoint_1 = 1
                         self.numerical_endpoint_2 = 2
         else:
-            if endpoint is Endpoint.ARROW and self.numerical_endpoint_2 == 1:
+            if endpoint == Endpoint.ARROW and self.numerical_endpoint_2 == 1:
                 self.numerical_endpoint_1 = 1
                 self.numerical_endpoint_2 = 1
             else:
-                if endpoint is Endpoint.ARROW:
+                if endpoint == Endpoint.ARROW:
                     self.numerical_endpoint_2 = 1
                 else:
-                    if endpoint is Endpoint.TAIL:
+                    if endpoint == Endpoint.TAIL:
                         self.numerical_endpoint_2 = -1
                     else:
-                        if endpoint is Endpoint.CIRCLE:
+                        if endpoint == Endpoint.CIRCLE:
                             self.numerical_endpoint_2 = 2
 
         if self.pointing_left(self.endpoint1, self.endpoint2):
@@ -216,20 +216,20 @@ class Edge:
 
         edge_string = node1.get_name() + " "
 
-        if endpoint1 is Endpoint.TAIL:
+        if endpoint1 == Endpoint.TAIL:
             edge_string = edge_string + "-"
         else:
-            if endpoint1 is Endpoint.ARROW:
+            if endpoint1 == Endpoint.ARROW:
                 edge_string = edge_string + "<"
             else:
                 edge_string = edge_string + "o"
 
         edge_string = edge_string + "-"
 
-        if endpoint2 is Endpoint.TAIL:
+        if endpoint2 == Endpoint.TAIL:
             edge_string = edge_string + "-"
         else:
-            if endpoint2 is Endpoint.ARROW:
+            if endpoint2 == Endpoint.ARROW:
                 edge_string = edge_string + ">"
             else:
                 edge_string = edge_string + "o"

--- a/causallearn/graph/Edges.py
+++ b/causallearn/graph/Edges.py
@@ -30,29 +30,29 @@ class Edges:
 
     # return true iff an edge is a bidrected edge <->
     def is_bidirected_edge(self, edge: Edge) -> bool:
-        return edge.get_endpoint1() is Endpoint.ARROW and edge.get_endpoint2() is Endpoint.ARROW
+        return edge.get_endpoint1() == Endpoint.ARROW and edge.get_endpoint2() == Endpoint.ARROW
 
     # return true iff the given edge is a directed edge -->
     def is_directed_edge(self, edge: Edge) -> bool:
-        if edge.get_endpoint1() is Endpoint.TAIL:
-            return edge.get_endpoint2() is Endpoint.ARROW
-        elif edge.get_endpoint2() is Endpoint.TAIL:
-            return edge.get_endpoint1() is Endpoint.ARROW
+        if edge.get_endpoint1() == Endpoint.TAIL:
+            return edge.get_endpoint2() == Endpoint.ARROW
+        elif edge.get_endpoint2() == Endpoint.TAIL:
+            return edge.get_endpoint1() == Endpoint.ARROW
         else:
             return False
 
     # return true iff the given edge is a partially oriented edge o->
     def is_partially_oriented_edge(self, edge: Edge) -> bool:
-        if edge.get_endpoint1() is Endpoint.CIRCLE:
-            return edge.get_endpoint2() is Endpoint.ARROW
-        elif edge.get_endpoint2() is Endpoint.CIRCLE:
-            return edge.get_endpoint1() is Endpoint.ARROW
+        if edge.get_endpoint1() == Endpoint.CIRCLE:
+            return edge.get_endpoint2() == Endpoint.ARROW
+        elif edge.get_endpoint2() == Endpoint.CIRCLE:
+            return edge.get_endpoint1() == Endpoint.ARROW
         else:
             return False
 
     # return true iff some edge is an undirected edge --
     def is_undirected_edge(self, edge: Edge) -> bool:
-        return edge.get_endpoint1() is Endpoint.TAIL and edge.get_endpoint2() is Endpoint.TAIL
+        return edge.get_endpoint1() == Endpoint.TAIL and edge.get_endpoint2() == Endpoint.TAIL
 
     def traverse_directed(self, node: Node, edge: Edge) -> Node | None:
         if node == edge.get_node1():

--- a/causallearn/graph/Endpoint.py
+++ b/causallearn/graph/Endpoint.py
@@ -18,3 +18,6 @@ class Endpoint(Enum):
     # Prints out the name of the type
     def __str__(self):
         return self.name
+
+    def __eq__(self, other):
+        return self.name == other.name

--- a/causallearn/graph/Endpoint.py
+++ b/causallearn/graph/Endpoint.py
@@ -20,4 +20,4 @@ class Endpoint(Enum):
         return self.name
 
     def __eq__(self, other):
-        return self.name == other.name
+        return self.value == other.value

--- a/causallearn/utils/GraphUtils.py
+++ b/causallearn/utils/GraphUtils.py
@@ -62,20 +62,20 @@ class GraphUtils:
 
         edge_string = node1.get_name() + " "
 
-        if endpoint1 is Endpoint.TAIL:
+        if endpoint1 == Endpoint.TAIL:
             edge_string = edge_string + "-"
         else:
-            if endpoint1 is Endpoint.ARROW:
+            if endpoint1 == Endpoint.ARROW:
                 edge_string = edge_string + "<"
             else:
                 edge_string = edge_string + "o"
 
         edge_string = edge_string + "-"
 
-        if endpoint2 is Endpoint.TAIL:
+        if endpoint2 == Endpoint.TAIL:
             edge_string = edge_string + "-"
         else:
-            if endpoint2 is Endpoint.ARROW:
+            if endpoint2 == Endpoint.ARROW:
                 edge_string = edge_string + ">"
             else:
                 edge_string = edge_string + "o"


### PR DESCRIPTION
## Updated files:
+ `causallearn/graph/Endpoint.py`: reload `__eq__`.
+ `causallearn/graph/Edge.py;Edges.py` and `causallearn/utils/GraphUtils.py`: replace all the "is Endpoint" with "== Endpoint", since identity comparison is unsafe.

## Reproduce the issue (as of https://github.com/py-why/causal-learn/commit/446b9a25ce9a85c09f059b90f6457740edcacce2):
```python
>>> from causallearn.graph import Endpoint
>>> arr1 = Endpoint.Endpoint.ARROW
>>>
>>> # module reload sometimes happens unknowingly; e.g., during discovery algorithms in causallearn
>>> import importlib; importlib.reload(Endpoint)
>>> arr2 = Endpoint.Endpoint.ARROW
>>>
>>> print(arr1, arr2, type(arr1), type(arr2), id(arr1), id(arr2))
ARROW ARROW <enum 'Endpoint'> <enum 'Endpoint'> 4302557296 4302743968
>>> arr1 == arr2 # oh no..
False
```

According to [Python doc](https://docs.python.org/3.8/library/enum.html#comparisons), equality comparisons for `Enum` are defined by identity comparison (i.e., `is`). Here we need to explicitly reimplement `__eq__` for attributed value comparison. See stackoverflow [1](https://stackoverflow.com/questions/39268052/how-to-compare-enums-in-python) [2](https://stackoverflow.com/questions/40371360/imported-enum-class-is-not-comparing-equal-to-itself).

## Incorrect SHD caused:
I experienced an incorrect SHD result due to this bug. The truth contains `X1 --> X2` and the estimation contains `X2 --> X1` (given by GES), but the returned SHD is 0, because [this line](https://github.com/py-why/causal-learn/blob/446b9a25ce9a85c09f059b90f6457740edcacce2/causallearn/graph/SHD.py#L44) is evaluated as False (i.e., ARROW != ARROW).

Potentially there might be more bugs related:

## Might be a fatal bug:
Endpoint comparisons are in the basic building blocks, while they're not used uniformly:
  - Sometimes identity comparison is used (bad!), e.g., https://github.com/py-why/causal-learn/blob/446b9a25ce9a85c09f059b90f6457740edcacce2/causallearn/graph/Edges.py#L37
  - Sometimes equality comparison (bad! but will be corrected by this pr), e.g., https://github.com/py-why/causal-learn/blob/446b9a25ce9a85c09f059b90f6457740edcacce2/causallearn/graph/SHD.py#L44
  - Sometimes value string comparison (good!), e.g., https://github.com/py-why/causal-learn/blob/446b9a25ce9a85c09f059b90f6457740edcacce2/causallearn/graph/Edges.py#L59
  - Sometimes value integer comparison (well, unclear but correct), e.g.,https://github.com/py-why/causal-learn/blob/446b9a25ce9a85c09f059b90f6457740edcacce2/causallearn/graph/Edge.py#L84

Let's take care of this if there will be a graph class refactoring.

## Merge plan
I'm not sure whether this pr should be merged right away. On the one hand, we need to ensure that the users receive accurate results (especially SHDs for evaluation in papers). On the other hand, we need to regenerate all the test benchmarks (which takes time) so that all the tests can pass. What do you think? @kunwuz @tofuwen
