### PR TITLE
ANM incompatible with scikit-learn >= 1.1.3

### DIFF
--- a/causallearn/search/FCMBased/ANM/ANM.py
+++ b/causallearn/search/FCMBased/ANM/ANM.py
@@ -49,7 +49,7 @@ class ANM(object):
 
         # fit Gaussian process, including hyperparameter optimization
         gpr.fit(X, y)
-        pred_y = gpr.predict(X)
+        pred_y = gpr.predict(X).reshape(-1, 1)
         return pred_y
 
     def cause_or_effect(self, data_x, data_y):


### PR DESCRIPTION
Pull 22199 into scikit-learn ([https://github.com/scikit-learn/scikit-learn/pull/22199]) changed the shape of the array returned by GaussianProcessRegressor which in turn introduced a bug causing ANM.cause_or_effect to return incorrect results. This pull requests reshapes the returned array using .reshape(-1, 1). 

The test_anm_pair unit test fails regardless of this fix and version of scikit-learn used. I'm not sure what that depends on but it doesn't seem to be related to this change since I get the value 0.14773 instead of 0.14736 for p_value_backward on older versions of scikit-learn regardless of this change. All other unit tests failed on newer versions of scikit-learn and pass with the change applied with both older and newer releases of scikit-learn.