### PR TITLE
Small bug in GeneralGraph.is_child_of

### DIFF
--- a/causallearn/graph/GeneralGraph.py
+++ b/causallearn/graph/GeneralGraph.py
@@ -508,7 +508,7 @@ class GeneralGraph(Graph, ABC):
     def is_child_of(self, node1: Node, node2: Node) -> bool:
         i = self.node_map[node1]
         j = self.node_map[node2]
-        return self.graph[i, j] == Endpoint.TAIL.value or self.graph[i, j] == Endpoint.ARROW_AND_ARROW.value
+        return self.graph[i, j] == Endpoint.ARROW.value or self.graph[i, j] == Endpoint.ARROW_AND_ARROW.value
 
     # Returns true iff node1 is a parent of node2.
     def is_parent_of(self, node1: Node, node2: Node) -> bool:


### PR DESCRIPTION
I think i found a small bug, node1 is_child_of node2 should return true when the endpoint at node1 is and arrow, not a tail. 