### PR TITLE
Add a function to load real-world datasets

### DIFF
--- a/causallearn/utils/Dataset.py
+++ b/causallearn/utils/Dataset.py
@@ -1,0 +1,41 @@
+import numpy as np
+import urllib.request
+from io import StringIO
+
+def load_dataset(dataset_name):
+    '''
+    Load real-world datasets. Processed datasets are from https://github.com/cmu-phil/example-causal-datasets/tree/main
+
+    Parameters
+    ----------
+    dataset_name : str, ['sachs', 'boston_housing', 'airfoil']
+
+    Returns
+    -------
+    data = np.array
+    labels = list
+    '''
+
+    url_mapping = {
+        'sachs': 'https://raw.githubusercontent.com/cmu-phil/example-causal-datasets/main/real/sachs/data/sachs.2005.continuous.txt',
+        'boston_housing': 'https://raw.githubusercontent.com/cmu-phil/example-causal-datasets/main/real/boston-housing/data/boston-housing.continuous.txt',
+        'airfoil': 'https://raw.githubusercontent.com/cmu-phil/example-causal-datasets/main/real/airfoil-self-noise/data/airfoil-self-noise.continuous.txt'
+    }
+
+    if dataset_name not in url_mapping:
+        raise ValueError("Invalid dataset name")
+
+    url = url_mapping[dataset_name]
+    with urllib.request.urlopen(url) as response:
+        content = response.read().decode('utf-8')  # Read content and decode to string
+
+    # Use StringIO to turn the string content into a file-like object so numpy can read from it
+    labels_array = np.genfromtxt(StringIO(content), delimiter="\t", dtype=str, max_rows=1)
+    data = np.loadtxt(StringIO(content), skiprows=1)
+
+    # Convert labels_array to a list of strings
+    labels_list = labels_array.tolist()
+    if isinstance(labels_list, str):  # handle the case where there's only one label
+        labels_list = [labels_list]
+
+    return data, labels_list


### PR DESCRIPTION
Load real-world datasets. Processed datasets are from https://github.com/cmu-phil/example-causal-datasets/tree/main. 

Description:

> 
> data, labels = load_dataset(dataset_name)
> 
> Parameters
> ----------
> dataset_name : str, ['sachs', 'boston_housing', 'airfoil']
> 
> Returns
> -------
> data = np.array
> labels = list

Usage example:

```
from causallearn.utils.Dataset import load_dataset

data, labels = load_dataset('sachs')
```

Output:

> [[2.640e+01 1.320e+01 8.820e+00 ... 1.700e+01 4.490e+01 4.000e+01]
 [3.590e+01 1.650e+01 1.230e+01 ... 3.370e+00 1.650e+01 6.150e+01]
 [5.940e+01 4.410e+01 1.460e+01 ... 1.140e+01 3.190e+01 1.950e+01]
 ...
 [2.810e+01 4.490e+00 1.880e+01 ... 1.000e+00 1.750e+00 2.000e+00]
 [3.460e+01 7.100e+00 5.730e+00 ... 4.450e+01 1.382e+03 2.440e+00]
 [3.050e+01 1.010e+00 7.300e+00 ... 1.000e+00 1.000e+00 1.650e+00]]
['raf', 'mek', 'plc', 'pip2', 'pip3', 'erk', 'akt', 'pka', 'pkc', 'p38', 'jnk']
