### PR TITLE
Fixed indexing error in dag2pag

### DIFF
--- a/causallearn/utils/DAG2PAG.py
+++ b/causallearn/utils/DAG2PAG.py
@@ -96,12 +96,13 @@ def dag2pag(dag: Dag, islatent: List[Node]) -> GeneralGraph:
 
     data = np.empty(shape=(0, len(observed_nodes)))
     independence_test_method = CIT(data, method=d_separation, true_dag=true_dag)
-
+    node_map = PAG.get_node_map()
+    sepset_reindexed = {(node_map[nodes[i]], node_map[nodes[j]]): sepset[(i, j)] for (i, j) in sepset}
     while change_flag:
         change_flag = False
         change_flag = rulesR1R2cycle(PAG, None, change_flag, False)
-        change_flag = ruleR3(PAG, sepset, None, change_flag, False)
-        change_flag = ruleR4B(PAG, -1, data, independence_test_method, 0.05, sep_sets=sepset,
+        change_flag = ruleR3(PAG, sepset_reindexed, None, change_flag, False)
+        change_flag = ruleR4B(PAG, -1, data, independence_test_method, 0.05, sep_sets=sepset_reindexed,
                           change_flag=change_flag,
                           bk=None, verbose=False)
     return PAG


### PR DESCRIPTION
The indices in the `sepset` may not be compatible with the indices used in the `PAG`, when ` ruleR3(PAG, sepset, ...)` is called.
This is, because the indices in the `sepset` depend on the order of `nodes`.
On the other hand, the indices returned by the `PAG.node_map()`-call within `ruleR3` depend on the order of `observed_nodes`, which is random, as `nodes` are converted to a `set` before being passed to the constructor of the `PAG.`


This pull request proposes a simple reindexing before the call of `ruleR3` and `ruleR4b`.