### PR TITLE
Endpoint comparison: check only for Endpoint instances

### DIFF
--- a/causallearn/graph/Endpoint.py
+++ b/causallearn/graph/Endpoint.py
@@ -20,4 +20,4 @@ class Endpoint(Enum):
         return self.name
 
     def __eq__(self, other):
-        return self.value == other.value
+        return isinstance(other, Endpoint) and self.value == other.value


### PR DESCRIPTION
## Updated files:
+ `causallearn/graph/Endpoint.py`: in the reloaded `__eq__`, replace `self.value == other.value` by `isinstance(other, Endpoint) and self.value == other.value`.

## Related to:
The issue: https://github.com/py-why/causal-learn/issues/149 and earlier pr https://github.com/py-why/causal-learn/pull/109. In some of our codes, the Endpoint comparison is in the form of `get_end_point(...) == Endpoint.ARROW`, while the first function may return None, instead of any Endpoint instances. This patch fixed this issue.

## Tests:
`TestFCI` can now pass, and the issues mentioned in https://github.com/py-why/causal-learn/issues/149 are addressed.