### PR TITLE
Update KCI.py

### DIFF
--- a/causallearn/utils/KCI/KCI.py
+++ b/causallearn/utils/KCI/KCI.py
@@ -191,7 +191,7 @@ class KCI_UInd(object):
         """
         T = Kxc.shape[0]
         if T > 1000:
-            num_eig = np.int(np.floor(T / 2))
+            num_eig = int(np.floor(T / 2))
         else:
             num_eig = T
         lambdax = eigvalsh(Kxc)


### PR DESCRIPTION
Changed np.int (deprecated) to int according to error message in numpy. Consider using np.int64 or np.int32 if precision is needed.

AttributeError: module 'numpy' has no attribute 'int'.
`np.int` was a deprecated alias for the builtin `int`. To avoid this error in existing code, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
