### PR TITLE
Fixed Issue#129

### DIFF
--- a/causallearn/utils/PCUtils/SkeletonDiscovery.py
+++ b/causallearn/utils/PCUtils/SkeletonDiscovery.py
@@ -120,8 +120,9 @@ def skeleton_discovery(
                     else:
                         if verbose:
                             print('%d dep %d | %s with p-value %f\n' % (x, y, S, p))
-                append_value(cg.sepset, x, y, tuple(sepsets))
-                append_value(cg.sepset, y, x, tuple(sepsets))
+                if (x, y) in edge_removal or not cg.G.get_edge(cg.G.nodes[x], cg.G.nodes[y]):
+                    append_value(cg.sepset, x, y, tuple(sepsets))
+                    append_value(cg.sepset, y, x, tuple(sepsets))
 
         if show_progress:
             pbar.refresh()

--- a/tests/TestSkeletonDiscovery.py
+++ b/tests/TestSkeletonDiscovery.py
@@ -1,0 +1,18 @@
+from unittest import TestCase
+import numpy as np
+from causallearn.search.ConstraintBased.PC import pc
+import networkx as nx
+from causallearn.utils.cit import chisq, fisherz, gsq, kci, mv_fisherz, d_separation
+
+
+class TestSkeletonDiscovery(TestCase):
+    def test_sepset(self):
+        truth_DAG_directed_edges = {(0, 2), (1, 2), (2, 3), (2, 4)}
+
+        true_dag_netx = nx.DiGraph()
+        true_dag_netx.add_nodes_from(list(range(5)))
+        true_dag_netx.add_edges_from(truth_DAG_directed_edges)
+
+        data = np.zeros((100, len(true_dag_netx.nodes)))  # just a placeholder
+        cg = pc(data, 0.05, d_separation, True, 0, -1, true_dag=true_dag_netx)
+        assert cg.sepset[0, 2] is None


### PR DESCRIPTION
# Updates
- Fixed an issue on updating the separated set. 
- Added a test for updating the separated set.

# Description

The `sepset` had been initialized with an empty set. But it should be recorded in `cg.sepset` when `x` and `y` are d-separated, given by `sepset`. Otherwise, `sepset` (the empty set) will be recorded in `cg.sepset`.

# Test Plan
``` sh
python -m unittest tests.TestPC # should pass
python -m unittest tests.TestSkeletonDiscovery # should pass
```
![image](https://github.com/py-why/causal-learn/assets/83860323/7e0241a6-2b3d-4421-8067-f6076cfe44cb)