### PR TITLE
updating pruning func for varlingam for faster processing

### DIFF
--- a/causallearn/search/FCMBased/lingam/var_lingam.py
+++ b/causallearn/search/FCMBased/lingam/var_lingam.py
@@ -319,10 +319,14 @@ class VARLiNGAM:
             obj = np.zeros((len(blocks)))
             exp = np.zeros(
                 (len(blocks), causal_order_no + n_features * self._lags))
-            for j, block in enumerate(blocks):
-                obj[j] = block[0][i]
-                exp[j:] = np.concatenate(
-                    [block[0][ancestor_indexes].flatten(), block[1:][:].flatten()], axis=0)
+            
+            # Create 3D array to hold flattened ancestor indices for each block
+            ancestor_indexes_flat = blocks[:, 0, ancestor_indexes].reshape(len(blocks), -1)
+            # Fill obj using advanced indexing
+            obj[:] = blocks[:, 0, i]
+            # Fill exp using advanced indexing
+            exp[:, :causal_order_no] = ancestor_indexes_flat
+            exp[:, causal_order_no:] = blocks[:, 1:].reshape(len(blocks), -1)
 
             # adaptive lasso
             gamma = 1.0


### PR DESCRIPTION
The recent update replaces a previous loop structure with a more efficient use of advanced indexing to fill the variables `obj` and `exp`. This improves code readability and may speed up execution, especially with large datasets.

Instead of iterating through each element `block` in `blocks`, a 3D array structure is now created to hold flattened ancestor indices for each block. This is done by extracting the ancestor indices for each block using `blocks[:, 0, ancestor_indexes]` and shaping them into a flat structure `ancestor_indexes_flat`.

Populating the `obj` variable is also optimized using advanced indexing, directly copying `blocks[:, 0, i]` into `obj` for more efficient assignment.

For the `exp` variable, advanced indexing is used similarly. Flattened ancestor indices are inserted into `exp[:, :causal_order_no]`, and remaining elements from `blocks[:, 1:].reshape(len(blocks), -1)` are placed into the corresponding position in `exp[:, causal_order_no:]`. This update improves code clarity and enhance execution speed drastically.

During my research I noticed that the pruning takes a very long time and this happens especially with longer data sets with many nodes, this should fix this issue. Atleast for Varlingam.