### PR TITLE
Update FCI.py for fixing isNoncollider

### DIFF
--- a/causallearn/search/ConstraintBased/FCI.py
+++ b/causallearn/search/ConstraintBased/FCI.py
@@ -322,7 +322,7 @@ def isNoncollider(graph: Graph, sep_sets: Dict[Tuple[int, int], Set[int]], node_
                   node_k: Node) -> bool:
     node_map = graph.get_node_map()
     sep_set = sep_sets.get((node_map[node_i], node_map[node_k]))
-    return sep_set is not None and sep_set.__contains__(graph.get_node_map()[node_j])
+    return sep_set is not None and sep_set.__contains__(node_map[node_j])
 
 
 def ruleR3(graph: Graph, sep_sets: Dict[Tuple[int, int], Set[int]], bk: BackgroundKnowledge | None, changeFlag: bool,

--- a/causallearn/search/ConstraintBased/FCI.py
+++ b/causallearn/search/ConstraintBased/FCI.py
@@ -320,7 +320,8 @@ def rulesR1R2cycle(graph: Graph, bk: BackgroundKnowledge | None, changeFlag: boo
 
 def isNoncollider(graph: Graph, sep_sets: Dict[Tuple[int, int], Set[int]], node_i: Node, node_j: Node,
                   node_k: Node) -> bool:
-    sep_set = sep_sets[(graph.get_node_map()[node_i], graph.get_node_map()[node_k])]
+    node_map = graph.get_node_map()
+    sep_set = sep_sets.get((node_map[node_i], node_map[node_k]))
     return sep_set is not None and sep_set.__contains__(graph.get_node_map()[node_j])
 
 


### PR DESCRIPTION
Editing isNoncollider() for FCI Algo

Fixing Bug:
If `sep_sets` does not contain certain node combination, it will led to a `KeyError`.

With this fix, `None` will automatically set by the `get()` func. Also `get_node_map()` will only called once to check `set_sets` for content, thus make it a bit more efficient.