### PR TITLE
Fixed a bug in finding possible parent sets in FCI

### DIFF
--- a/causallearn/search/ConstraintBased/FCI.py
+++ b/causallearn/search/ConstraintBased/FCI.py
@@ -582,8 +582,7 @@ def is_possible_parent(graph: Graph, potential_parent_node, child_node):
     if not graph.is_adjacent_to(potential_parent_node, child_node):
         return False
 
-    if graph.get_endpoint(child_node, potential_parent_node) == Endpoint.ARROW or \
-    graph.get_endpoint(potential_parent_node, child_node) == Endpoint.TAIL:
+    if graph.get_endpoint(child_node, potential_parent_node) == Endpoint.ARROW: 
         return False
     else:
         return True


### PR DESCRIPTION
I realized there's a bug in the function `is_possible_parent` that I created for the orientation rules in FCI. 