### PR TITLE
fix: handle residuals array is empty

### DIFF
--- a/causallearn/search/ScoreBased/ExactSearch.py
+++ b/causallearn/search/ScoreBased/ExactSearch.py
@@ -365,6 +365,8 @@ def bic_score_node(X, i, structure):
                                             b=X[:, i],
                                             rcond=None)
     bic = n * np.log(residual / n) + len(structure) * np.log(n)
+    if bic.size == 0:
+        return NEGINF   # Return negative infinity if bic is empty
     return bic.item()
 
 


### PR DESCRIPTION
What if the correlation matrix is singular? In ExactSearch.bic_exact_search() handle residuals array is empty. It means that the least squares problem does not have a unique solution or has no degrees of freedom left to compute residuals. Return BIC score of negative infinity.