### PR TITLE
Update default score function in BOSS.py

### DIFF
--- a/causallearn/search/PermutationBased/BOSS.py
+++ b/causallearn/search/PermutationBased/BOSS.py
@@ -23,7 +23,7 @@ from causallearn.utils.DAG2CPDAG import dag2cpdag
 
 def boss(
     X: np.ndarray,
-    score_func: str = "local_score_BIC_from_cov",
+    score_func: str = "local_score_BIC",
     parameters: Optional[Dict[str, Any]] = None,
     verbose: Optional[bool] = True,
     node_names: Optional[List[str]] = None,


### PR DESCRIPTION
Change the default score function to local_score_BIC since local_score_BIC_from_cov requires a different type of input.