### PR TITLE
Fix `d_separated` deprecation warning

### DIFF
--- a/causallearn/utils/DAG2PAG.py
+++ b/causallearn/utils/DAG2PAG.py
@@ -3,7 +3,6 @@ from typing import List
 
 import numpy as np
 import networkx as nx
-from networkx.algorithms import d_separated
 
 from causallearn.graph.Dag import Dag
 from causallearn.graph.Edge import Edge
@@ -66,7 +65,7 @@ def dag2pag(dag: Dag, islatent: List[Node], isselection: List[Node] = []) -> Gen
             for Z in combinations(observed_nodes, l):
                 if nodex in Z or nodey in Z:
                     continue
-                if d_separated(dg, {nodes_ids[nodex]}, {nodes_ids[nodey]}, set(nodes_ids[z] for z in Z) | set([nodes_ids[s] for s in isselection])):
+                if nx.is_d_separator(dg, {nodes_ids[nodex]}, {nodes_ids[nodey]}, set(nodes_ids[z] for z in Z) | set([nodes_ids[s] for s in isselection])):
                     if edge:
                         PAG.remove_edge(edge)
                     sepset[(nodes_ids[nodex], nodes_ids[nodey])] |= set(Z)

--- a/causallearn/utils/PCUtils/Helper.py
+++ b/causallearn/utils/PCUtils/Helper.py
@@ -419,7 +419,7 @@ def draw_graph(nx_graph):
 def is_dsep(nx_graph, x, y, Z):
     "Return True if x and y are d-separated by the set Z in nx_graph (networkx graph object) and False otherwise"
     S = set([str(i) for i in Z])
-    return nx.d_separated(nx_graph, {str(x)}, {str(y)}, S)
+    return nx.is_d_separator(nx_graph, {str(x)}, {str(y)}, S)
 
 
 #######################################################################################################################

--- a/causallearn/utils/cit.py
+++ b/causallearn/utils/cit.py
@@ -529,8 +529,8 @@ class D_Separation(CIT_Base):
     def __call__(self, X, Y, condition_set=None):
         Xs, Ys, condition_set, cache_key = self.get_formatted_XYZ_and_cachekey(X, Y, condition_set)
         if cache_key in self.pvalue_cache: return self.pvalue_cache[cache_key]
-        p = float(nx.d_separated(self.true_dag, {Xs[0]}, {Ys[0]}, set(condition_set)))
-        # pvalue is bool here: 1 if is_d_separated and 0 otherwise. So heuristic comparison-based uc_rules will not work.
+        p = float(nx.is_d_separator(self.true_dag, {Xs[0]}, {Ys[0]}, set(condition_set)))
+        # pvalue is bool here: 1 if is_d_separator and 0 otherwise. So heuristic comparison-based uc_rules will not work.
 
         # here we use networkx's d_separation implementation.
         # an alternative is to use causal-learn's own d_separation implementation in graph class:


### PR DESCRIPTION
Source: https://networkx.org/documentation/stable/_modules/networkx/algorithms/d_separation.html

```
DeprecationWarning: d_separated is deprecated and will be removed in NetworkX v3.5.Please use `is_d_separator(G, x, y, z)`.
```