### PR TITLE
Add option to control depth in PC algorithm

### DIFF
--- a/causallearn/utils/PCUtils/SkeletonDiscovery.py
+++ b/causallearn/utils/PCUtils/SkeletonDiscovery.py
@@ -21,7 +21,7 @@ def skeleton_discovery(
     background_knowledge: BackgroundKnowledge | None = None, 
     verbose: bool = False,
     show_progress: bool = True,
-    node_names: List[str] | None = None, 
+    node_names: List[str] | None = None, max_k=None,
 ) -> CausalGraph:
     """
     Perform skeleton discovery
@@ -63,6 +63,8 @@ def skeleton_discovery(
     pbar = tqdm(total=no_of_var) if show_progress else None
     while cg.max_degree() - 1 > depth:
         depth += 1
+        if max_k is not None and depth > max_k:
+            break
         edge_removal = []
         if show_progress:
             pbar.reset()


### PR DESCRIPTION
This PR adds a max_k parameter to the PC algorithm implementation to limit the maximum size of conditioning sets during independence testing, providing better computational control and performance optimization.
Files Modified:
causallearn/search/ConstraintBased/PC.py
causallearn/utils/PCUtils/SkeletonDiscovery.py