### PR TITLE
Fix invalid escape sequence warnings in KCI and Kernel docstrings

### DIFF
--- a/causallearn/utils/KCI/KCI.py
+++ b/causallearn/utils/KCI/KCI.py
@@ -474,7 +474,7 @@ class KCI_CInd(object):
         return Kx, Ky, Kzx, Kzy
 
     def KCI_V_statistic(self, Kx, Ky, Kzx, Kzy):
-        """
+        r"""
         Compute V test statistic from kernel matrices Kx and Ky
         Parameters
         ----------

--- a/causallearn/utils/KCI/Kernel.py
+++ b/causallearn/utils/KCI/Kernel.py
@@ -41,7 +41,7 @@ class Kernel(object):
         return K - (K_colsums[None, :] + K_colsums[:, None]) / n + (K_allsum / n ** 2)
 
     def center_kernel_matrix_regression(K: ndarray, Kz: ndarray, epsilon: float):
-        """
+        r"""
         Centers the kernel matrix via a centering matrix R=I-Kz(Kz+\epsilonI)^{-1} and returns RKR
         """
         n = shape(K)[0]


### PR DESCRIPTION
# Fix invalid escape sequence warnings in KCI and Kernel docstrings

This PR fixes `SyntaxWarning: invalid escape sequence '\e'` that appears on Python 3.12+ / 3.13 when importing `causallearn`.

## Problem
Some docstrings in `KCI.py` and `Kernel.py` include LaTeX-like math expressions such as `\epsilon`.  
In normal Python strings, `\e` is treated as an escape sequence, which is invalid and now triggers a warning:

```❯ uv run analysis
.venv/lib/python3.13/site-packages/causallearn/utils/KCI/KCI.py:500: SyntaxWarning: invalid escape sequence '\e'
  With this we could save one repeated calculation of pinv(Kzy+\epsilonI), which consumes most time.
.venv/lib/python3.13/site-packages/causallearn/utils/KCI/Kernel.py:45: SyntaxWarning: invalid escape sequence '\e'
  Centers the kernel matrix via a centering matrix R=I-Kz(Kz+\epsilonI)^{-1} and returns RKR
```
## Solution
- Converted affected docstrings into **raw strings** (`r"""..."""`).

## Impact
- **No code or functional changes.**
- Silences warnings on Python 3.12+ and improves readability of the math in docstrings.
- Keeps the intended LaTeX-style formatting intact for users and documentation tools.