### PR TITLE
Fix implementation of the structure prior term of the BDeu score

### DIFF
--- a/causallearn/score/LocalScoreFunction.py
+++ b/causallearn/score/LocalScoreFunction.py
@@ -148,7 +148,7 @@ def local_score_BDeu(Data: ndarray, i: int, PAi: List[int], parameters=None) -> 
 
     BDeu_score = 0
     # first term
-    vm = Data.shape[0] - 1
+    vm = Data.shape[1] - 1
     BDeu_score += len(PAi) * np.log(structure_prior / vm) + (vm - len(PAi)) * np.log(
         1 - (structure_prior / vm)
     )


### PR DESCRIPTION
According to the Bernoulli edge-based structure prior combined with the BDeu marginal likelihood, the structure prior can be written as

$$
\log p(G) = \sum_{i=1}^{d} \left[ |PA_i| \log\left(\frac{\kappa}{d-1}\right) + (d - 1 - |PA_i|)\log\left(1 - \frac{\kappa}{d-1}\right) \right],
$$

where $d$ denotes the number of variables (features), since each node can have at most $d-1$ possible parents.

In the original implementation, however, the `Data` array has shape `(number_of_samples, number_of_variables)`. Therefore, `Data.shape[1]` should be used instead of `Data.shape[0]` when computing the structure prior.