### PR TITLE
fixed cycle detection in exists_directed_cycle

### DIFF
--- a/causallearn/utils/GraphUtils.py
+++ b/causallearn/utils/GraphUtils.py
@@ -460,10 +460,10 @@ class GraphUtils:
 
                 if c is None:
                     continue
-                if c in V:
-                    continue
                 if c == node_to:
                     return True
+                if c in V:
+                    continue
 
                 V.append(c)
                 Q.append(c)


### PR DESCRIPTION
The cycle detection is broken, since the case `c==node_to` can never be reached since `c in V` comes before, which is true when `node_from==node_to` as is the case with the cycle check.

Please let me know if I am mistaken, but a simple graph A->B->C and C->A was determined to have no cycle without this fix.