### PR TITLE
docs: correct RCIT num_f default to 100

### DIFF
--- a/causallearn/utils/RCIT/RCIT.py
+++ b/causallearn/utils/RCIT/RCIT.py
@@ -31,7 +31,7 @@ class RCIT(object):
             - "perm" for permutation testing
             Default is "lpd4".
         num_f : int
-            Number of features for conditioning set. Default is 25.
+            Number of features for conditioning set. Default is 100.
         num_f2 : int
             Number of features for non-conditioning sets. Default is 5.
         rcit : bool


### PR DESCRIPTION
Closes #258.

The RCIT `__init__` docstring stated `num_f` defaults to 25, but the actual default in the signature is 100. Updates the docstring to match.