### PR TITLE
Visit GST grow branches in descending score order (BOSS/GRaSP)

### DIFF
--- a/causallearn/search/PermutationBased/gst.py
+++ b/causallearn/search/PermutationBased/gst.py
@@ -22,7 +22,10 @@ class GSTNode:
             parents.remove(add)
             branch = GSTNode(self.tree, add, score)
             if score > self.grow_score: self.branches.append(branch)
-        self.branches.sort()
+        # Visit higher-scoring grow branches first, matching TETRAD's
+        # GrowShrinkTree: GSTNode.compareTo() is ascending in growScore, but
+        # grow() sorts with Collections.reverseOrder(). See py-why/causal-learn#264.
+        self.branches.sort(reverse=True)
 
     def shrink(self, parents):
         self.remove = []

--- a/tests/TestGST.py
+++ b/tests/TestGST.py
@@ -1,0 +1,69 @@
+import unittest
+
+import numpy as np
+
+from causallearn.search.PermutationBased.gst import GST
+
+
+# Deterministic local scores for vertex 0 over candidate parents {1, 2, 3},
+# taken from py-why/causal-learn#264. BOSS uses a higher-is-better score.
+# S({1}) and S({2}) use the issue's reported trace values; the remaining
+# entries use the issue's local-score table.
+_LOCAL_SCORES = {
+    frozenset():            0.0,
+    frozenset({1}):         2.0837,
+    frozenset({2}):         4.3568,
+    frozenset({3}):         1.53,
+    frozenset({1, 2}):     -0.03,
+    frozenset({1, 3}):      3.29,
+    frozenset({2, 3}):      2.33,
+    frozenset({1, 2, 3}):  -0.25,
+}
+
+
+class _MockScore:
+    """Minimal score object exposing only the interface that GST relies on."""
+
+    def __init__(self, n_vars, scores):
+        # GST reads data.shape[1] to enumerate the candidate parents.
+        self.data = np.zeros((1, n_vars))
+        self._scores = scores
+
+    def score(self, i, PAi):
+        return self._scores[frozenset(PAi)]
+
+    def score_nocache(self, i, PAi):
+        return self._scores[frozenset(PAi)]
+
+
+class TestGST(unittest.TestCase):
+    """Regression test for GST grow-branch ordering (py-why/causal-learn#264).
+
+    BOSS uses a higher-is-better score, and TETRAD's GrowShrinkTree visits grow
+    branches in descending growScore order. The trace path -- not just the
+    presentation order -- depends on this direction, so the highest-scoring grow
+    branch reachable within the prefix must be visited first.
+    """
+
+    def test_grow_branches_sorted_descending(self):
+        gst = GST(0, _MockScore(4, _LOCAL_SCORES))
+        # Force the root to grow over all candidates {1, 2, 3}.
+        gst.trace([1, 2, 3])
+        grow_scores = [branch.grow_score for branch in gst.root.branches]
+        self.assertEqual(grow_scores, sorted(grow_scores, reverse=True))
+        # 2 (4.3568) > 1 (2.0837) > 3 (1.53)
+        self.assertEqual([branch.add for branch in gst.root.branches], [2, 1, 3])
+
+    def test_trace_follows_highest_scoring_branch(self):
+        # With prefix [1, 2], both {1} and {2} are reachable grow branches.
+        # Descending order (TETRAD-style) visits {2} first    -> parents {2}.
+        # Ascending order (the pre-fix behavior) would visit {1} -> parents {1}.
+        gst = GST(0, _MockScore(4, _LOCAL_SCORES))
+        parents = []
+        score = gst.trace([1, 2], parents)
+        self.assertEqual(parents, [2])
+        self.assertAlmostEqual(score, 4.3568, places=6)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Summary

Fixes the grow-branch sort direction in `causallearn/search/PermutationBased/gst.py` so the Grow-Shrink Tree visits higher-scoring grow branches first, matching TETRAD's `GrowShrinkTree` (discussed in #264).

### Root cause

BOSS uses a higher-is-better score. In TETRAD's `edu.cmu.tetrad.search.utils.GrowShrinkTree`, `GSTNode.compareTo()` orders by ascending `growScore`, but `grow()` sorts with `this.branches.sort(Collections.reverseOrder())`, so branches are visited in **descending** `growScore` order.

In causal-learn, `GSTNode.__lt__` is ascending and `grow()` called `self.branches.sort()` — i.e. **ascending**, the opposite direction.

### Why it matters (not just presentation order)

`GST.trace` descends into the **first** prefix-matching branch and returns its shrink score, so the sort direction changes the returned score and parent set for a given prefix. With the deterministic mock scores from #264 and prefix `[1, 2]`:

```text
ascending  -> score 2.0837, parents {1}
descending -> score 4.3568, parents {2}
```

Visiting the best improving add first follows the more promising path — a better local approximation that also prunes more of the tree.

### Change

```python
# grow()
self.branches.sort(reverse=True)
```

I kept `__lt__` ascending and reversed at the sort site, mirroring TETRAD's `compareTo` + `Collections.reverseOrder()` (equivalent to inverting the comparator, the other form proposed in #264). This `GST` is shared by both `boss` and `grasp`, so both now use the descending (TETRAD-style) traversal.

### Scope

This PR changes only the branch **traversal order**. Other existing behavior is intentionally left as-is: grow branches are still included on strict improvement (`score > self.grow_score`; TETRAD uses `>=`), and background knowledge (`forbidden`/`required`) remains unimplemented as before. Aligning those with TETRAD is out of scope here.

### Performance (from #264; synthetic linear-Gaussian, BIC-from-cov, avg_degree=2, lambda=2)

p=50, n=1000:

| seed | current ascending | TETRAD-style descending | speedup | CPDAG edges |
| ---: | ---: | ---: | ---: | ---: |
| 101 | 1.376s | 0.269s | 5.12x | 48 / 48 |
| 102 | 0.806s | 0.236s | 3.42x | 44 / 44 |
| 103 | 1.543s | 0.315s | 4.91x | 46 / 46 |
| 104 | 0.714s | 0.209s | 3.42x | 40 / 40 |

Mean wall time 1.110s → 0.257s (4.32x).

p=100, n=1000:

| seed | current ascending | TETRAD-style descending | speedup | CPDAG edges |
| ---: | ---: | ---: | ---: | ---: |
| 101 | 3.603s | 1.107s | 3.25x | 86 / 86 |
| 102 | 10.686s | 1.816s | 5.89x | 111 / 110 |
| 103 | 13.717s | 1.753s | 7.82x | 108 / 108 |
| 104 | 6.377s | 1.344s | 4.75x | 101 / 102 |

Mean wall time 8.596s → 1.505s (5.71x). As noted in #264, in some seeds the returned CPDAG edge count also changes.

### Test

Adds `tests/TestGST.py`, a focused, deterministic regression test over the #264 mock scores: it asserts the root grow branches are ordered by descending score and that tracing prefix `[1, 2]` selects the higher-scoring parent `{2}`. The test fails on the previous ascending behavior and passes after this change.

Closes #264
