### PR TITLE
Fix local_score_BDeu KeyError on pandas >= 2.0

### DIFF
--- a/causallearn/score/LocalScoreFunction.py
+++ b/causallearn/score/LocalScoreFunction.py
@@ -196,7 +196,13 @@ def local_score_BDeu(Data: ndarray, i: int, PAi: List[int], parameters=None) -> 
         # calculate N_{ijk}: for each parent config, count occurrences of each X_i value
         Nijk_map = {}
         for ij in Nij_map_keys_list:
-            group = Data_pd_group_Nij.get_group((ij,) if not isinstance(ij, tuple) else ij)
+            # For a single grouper, pandas >= 2.0 expects the scalar key while
+            # older pandas accepted a 1-tuple; try the scalar first and fall
+            # back so BDeu works across pandas versions.
+            try:
+                group = Data_pd_group_Nij.get_group(ij)
+            except (KeyError, ValueError):
+                group = Data_pd_group_Nij.get_group((ij,) if not isinstance(ij, tuple) else ij)
             counts = group[xi_col].value_counts().reset_index()
             counts.columns = [xi_col, "times"]
             Nijk_map[ij] = counts


### PR DESCRIPTION
local_score_BDeu groups by a single parent column and calls GroupBy.get_group((ij,)). On pandas >= 2.0 a single grouper expects the scalar key, so the 1-tuple raises KeyError — making GES with score_func='local_score_BDeu' unusable on any current pandas (the bug is in the latest release 0.1.4.7 and on main).

Try the scalar key first and fall back to the 1-tuple form, so BDeu works on both old and new pandas. The resulting scores match a direct boolean-mask computation, and tests/TestGES.py::test_ges_load_discrete_10_with_local_score_BDeu runs to completion.